### PR TITLE
Bailout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,10 @@
-# eosusd
-Website: https://eosUSD.com  
-Whitepaper: https://eosUSD.com/eosUSD.pdf
+# VIGOR lending DAC
 
-# Usage
+VIGOR is a decentralized autonomous community building finance dApps on the eosio blockchain, first product is a crypto backed stablecoin called VIGOR powered by the VIG utility token.
 
-Build your eos development image
+Help us build VIGOR -> Register as a candidate of the DAC at vig.ai or vigor.ai or vigstack.io (need to ask us for a stake token) and fill out a profile, top 21 voted candidates can claim VIG every day
 
-```
-docker build -t my/eos .
-```
-
-In a new terminal, start the required environment
-
-```
-docker-compose up # down or rm to clean up
-```
-
-Initialize the smart contract
-
-```
-sh bootstrap.sh # it prepares the environment
-alias cleos="docker exec -it nodeos cleos --url http://127.0.0.1:8888 --wallet-url http://keosd:8901"
-
-# Environment is ready, start here your tests/demo
-# ..and / or use Scatter configured for local Testnet
-cleos get info
-cleos get table eosusdcom111 eosusdcom111 user
-
-```
-
-Congrats, here are your first Localnet eosUSD
+Whitepaper: https://vig.ai/vigor.pdf
+Summary: https://vig.ai/vigorstablecoin.pdf
+Website: https://www.vigorstablecoin.com
+Telegram: https://t.me/vigorstablecoin

--- a/contracts/vigor/include/vigor.hpp
+++ b/contracts/vigor/include/vigor.hpp
@@ -74,6 +74,7 @@ CONTRACT vigor : public eosio::contract {
       void stressins();
       double stressinsx(name usern);
       double portVarianceCol(name usern);
+      double portVarianceIns(name usern);
       double portVarianceIns();
       void update(name usern);
       void payfee(name usern);


### PR DESCRIPTION
bailout model was re-written.

in the event of a loan gone bad, an insurer takes their share of the given failed collateral and bad debt into their collateral vector. to recap that, the system automatically moves some of their insurance assets into thier collateral vector so that the debt is overcollateralized by a default amount, called recapRequirement (the default amount calculated to be able to cover normal volatility, to survive a 1 weekly standard deviation move). now the question, what if the insurer does not have enough insurance assets to recap by the default amount? what if they have slightly less?
if the insurers insurance assets are less than the default recap amount needed, then they recap with however much insurance they actually have. all of their remaining insurance assets will be moved over to collateral and if it is still less than the bad debt received then that particular insurer now gets bailed out
and this bailout recursion culminates with the reserve taking the bad debt, accumulating also all the failed insurers remaining insurance assets along the way